### PR TITLE
uniqueidentifier converted to 255 char string

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -352,7 +352,7 @@ WHILE @Column_ID IS NOT NULL
  'COALESCE('''''''' + RTRIM(CONVERT(char,' + @Column_Name + ',127))+'''''''',''NULL'')'
  WHEN @Data_Type IN ('uniqueidentifier') 
  THEN 
- 'COALESCE('''''''' + REPLACE(CONVERT(char(255),RTRIM(' + @Column_Name + ')),'''''''','''''''''''')+'''''''',''NULL'')'
+ 'COALESCE('''''''' + REPLACE(RTRIM(CONVERT(char(255),' + @Column_Name + ')),'''''''','''''''''''')+'''''''',''NULL'')'
  WHEN @Data_Type IN ('text') 
  THEN 
  'COALESCE('''''''' + REPLACE(CONVERT(varchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -359,6 +359,9 @@ WHILE @Column_ID IS NOT NULL
  WHEN @Data_Type IN ('ntext') 
  THEN 
  'COALESCE('''''''' + REPLACE(CONVERT(nvarchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
+ WHEN @Data_Type IN ('xml') 
+ THEN 
+ 'COALESCE('''''''' + REPLACE(CONVERT(nvarchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
  WHEN @Data_Type IN ('binary','varbinary') 
  THEN 
  'COALESCE(RTRIM(CONVERT(char,' + 'CONVERT(int,' + @Column_Name + '))),''NULL'')' 


### PR DESCRIPTION
uniqueidentifier are converted to a 255 char string so the first 36 chars are
followed by 219 blank spaces.

I moved the RTRIM 

``` sql
DECLARE @Column_Name UNIQUEIDENTIFIER = 'EDAB8EA9-76D1-45EE-BC09-93CBDB63A54A'
SELECT COALESCE('''' + REPLACE(CONVERT(char(255),RTRIM(@Column_Name)),'''','''''')+'''','NULL')
SELECT COALESCE('''' + REPLACE(RTRIM(CONVERT(char(255),@Column_Name)),'''','''''')+'''','NULL')
```
