### PR TITLE
add a new parameter @source_as_temp_table to improve merge script performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ GO
 
 I want to export one certain set of data from A(Id, Code, Column1, Column2) and B(Id, AId, Data1, Data2), which is a 1-N mapping, when applying on a different DB I would like remain the relationship between them but not using identity insert, based on that in A table there are other columns is unique enough to match the target
 
+```
 DECLARE @from_query VARCHAR(max) = 'from A where Id IN (' + @sIdString + ')'
 EXEC sp_generate_merge 'A', @include_use_db = 0,  @source_as_temp_table = 1, @ommit_identity = 0, @results_to_text =1,
 		@from = @from_query, @delete_if_not_matched = 0, @update_only_if_changed = 0,
@@ -121,7 +122,7 @@ EXEC sp_generate_merge 'A', @include_use_db = 0,  @source_as_temp_table = 1, @om
 		@script_after_merge = '',
 		@drop_temp_table = 0, @output_identity_into_temp = 1
 
-----------------------------------------------------WP_Web_Policy_Air-----------------------------------------------------------
+
 SET @from_query = 'from B where Id IN (' + @sBIdString + ')'
 EXEC sp_generate_merge 'B', @include_use_db = 0,  @source_as_temp_table = 1, @ommit_identity = 0, @results_to_text =1,
 		@from = @from_query, @delete_if_not_matched = 0,  @update_only_if_changed = 0,
@@ -134,3 +135,4 @@ EXEC sp_generate_merge 'B', @include_use_db = 0,  @source_as_temp_table = 1, @om
 										ON T1.[Id_Source] = T.[AId];',
 		@script_after_merge = '',
 		@drop_temp_table = 0, @output_identity_into_temp = 1, @ignore_duplicates_for_update = 1
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The generated MERGE statement populates the target table to match the source dat
 When the generated MERGE statement is executed, the following logic is applied based on whether a match is found:
 
 - If the source row does not exist in the target table, an `INSERT` is performed
-- If a given row in the target table does not exist in the source, a `DELETE` is performed
+- If a given row in the target table does not exist in the source, a `DELETE` is performed (causing huge slowness)
 - If the source row already exists in the target table and has changed, an `UPDATE` is performed
 - If the source row already exists in the target table but the data has not changed, no action is performed (configurable)
 
@@ -46,7 +46,7 @@ I would also like to acknowledge:
  
 ## Installation
 Simply execute the script, which will install it in `[master]` database as a system procedure (making it executable within user databases).
-
+The use master is currently removed from it in case login limitation won't allow creation in master, create in user database works too.
 
 ## Known Limitations
 This procedure has explicit support for the following datatypes: (small)datetime(2), (n)varchar, (n)text, (n)char, int, float, real, (small)money, timestamp, rowversion, uniqueidentifier and (var)binary. All others are implicitly converted to their CHAR representations so YMMV depending on the datatype. Additionally, this procedure has not been extensively tested with UNICODE datatypes.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This system stored procedure takes a table name as a parameter and generates a `
 This is useful if you need to [migrate static data between databases](http://support.ready-roll.com/customer/portal/articles/437299-including-static-data-in-db-deployments), eg. the generated MERGE statement can be included in source control and used to deploy data between DEV/TEST/PROD.
 
 The stored procedure itself is installed within the `[master]` database as a system object, allowing the proc to be called within the context of user databases (e.g. `EXEC Northwind.dbo.sp_generate_merge 'Region'`)
-
+(The above is now commented out so that it creates in user database, so example changes to  (e.g. `EXEC dbo.sp_generate_merge 'Region'`))
 Key features:
 
 - Include or exclude specific columns from output (eg. exclude DateCreated/DateModified columns)
@@ -100,4 +100,37 @@ GO
 SET NOCOUNT OFF
 GO
 ```
+## Changes in this fork
+1. Commented out using master so it creates on user db instead
+2. The query will became really slow with more data invovled and sql server would not even able to run it as all data is forming into a memory table. Therefore a new parameter was introduced @source_as_temp_table which will put those raw data into a tempporary table first and then use that as a source to improve performance
+3. Along with @source_as_temp_table @output_identity_into_temp will use OUTPUT keyword to write all matching identity pk back into the temporary table with extra '_Source' appended to the identity column name as a new column, so that when exporting linked record between table when identiy insert is not an option
+4. In order to make #3 mapping actually work @script_before_merge @script_after_merge was introduced to ingect sql code for mapping, which also kind of need @drop_temp_table
+5. Added @ignore_duplicates_for_update so that when source data for no reason has duplicates except identity rerun the script won't causing trouble with rownumber
+6. Added @different_join_columns so that the match can be used on different columns
+7. @different_join_nullable_columns is a subset of @different_join_columns to tell those columns might be nullable so that we match them with both null check on source and target
 
+## Example
+
+I want to export one certain set of data from A(Id, Code, Column1, Column2) and B(Id, AId, Data1, Data2), which is a 1-N mapping, when applying on a different DB I would like remain the relationship between them but not using identity insert, based on that in A table there are other columns is unique enough to match the target
+
+DECLARE @from_query VARCHAR(max) = 'from A where Id IN (' + @sIdString + ')'
+EXEC sp_generate_merge 'A', @include_use_db = 0,  @source_as_temp_table = 1, @ommit_identity = 0, @results_to_text =1,
+		@from = @from_query, @delete_if_not_matched = 0, @update_only_if_changed = 0,
+		@new_identity_in_temp_table = 1, @different_join_columns = 'Code,',
+ 		@script_before_merge = '',
+		@script_after_merge = '',
+		@drop_temp_table = 0, @output_identity_into_temp = 1
+
+----------------------------------------------------WP_Web_Policy_Air-----------------------------------------------------------
+SET @from_query = 'from B where Id IN (' + @sBIdString + ')'
+EXEC sp_generate_merge 'B', @include_use_db = 0,  @source_as_temp_table = 1, @ommit_identity = 0, @results_to_text =1,
+		@from = @from_query, @delete_if_not_matched = 0,  @update_only_if_changed = 0,
+		@new_identity_in_temp_table = 1, @different_join_columns = 'AId,Data1,Data2,',
+		@different_join_nullable_columns = 'Data2,',
+ 		@script_before_merge = 'UPDATE T
+								SET T.[AId] = T1.[Id]
+								FROM  #tempB AS T 
+									JOIN #tempA AS T1
+										ON T1.[Id_Source] = T.[AId];',
+		@script_after_merge = '',
+		@drop_temp_table = 0, @output_identity_into_temp = 1, @ignore_duplicates_for_update = 1

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -645,7 +645,7 @@ BEGIN
 		SET @output += @b + 'USING (SELECT ' + @Column_List + ' FROM #temp' + @table_name
 	END
 	ELSE BEGIN
-		SET @output += @b + 'USING (SELECT ROW_NUMBER() OVER(PARTITION BY ' + @Column_List + ' ORDER BY ' + @IDN + ' DESC) AS RowNum,' + @Column_List + ' FROM #temp' + @table_name
+		SET @output += @b + 'USING (SELECT ROW_NUMBER() OVER(PARTITION BY ' + REPLACE(@Column_List, @IDN +',', '') + ' ORDER BY ' + @IDN + ' DESC) AS RowNum,' + @Column_List + ' FROM #temp' + @table_name
 	END
 END
 ELSE BEGIN

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -754,6 +754,8 @@ SET @output += @b + ''
 IF @source_as_temp_table = 1 AND @drop_temp_table = 1
 BEGIN
 	SET @output += @b + 'DROP TABLE #temp' + @table_name
+	SET @output += @b + @batch_separator
+	SET @output += @b
 END
 
 IF @results_to_text = 1

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -45,7 +45,8 @@ CREATE PROC sp_generate_merge
  @script_after_merge varchar(8000) = NULL,
  @drop_temp_table bit = 1,
  @output_identity_into_temp bit = 0,
- @ignore_duplicates_for_update bit = 0
+ @ignore_duplicates_for_update bit = 0,
+ @columns_order_by varchar(8000) = NULL
 )
 AS
 BEGIN
@@ -517,8 +518,8 @@ SET @Actual_Values =
  'SELECT ' + 
  CASE WHEN @top IS NULL OR @top < 0 THEN '' ELSE ' TOP ' + LTRIM(STR(@top)) + ' ' END + 
  '''' + 
- ' '' + CASE WHEN ROW_NUMBER() OVER (ORDER BY ' + @PK_column_list + ') = 1 THEN '' '' ELSE ' + CASE WHEN @source_as_temp_table = 0 THEN ''',''' ELSE ''' UNION ALL ''' END + ' END' + CASE WHEN @source_as_temp_table = 0 THEN '+ ''(''+ ' ELSE ' + '' SELECT '' + ' END + @Actual_Values + CASE WHEN @source_as_temp_table = 0 THEN '+'')''' ELSE '' END + ' ' + 
- COALESCE(@from,' FROM ' + @Source_Table_Qualified + ' (NOLOCK) ORDER BY ' + @PK_column_list)
+ ' '' + CASE WHEN ROW_NUMBER() OVER (ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) + ') = 1 THEN '' '' ELSE ' + CASE WHEN @source_as_temp_table = 0 THEN ''',''' ELSE ''' UNION ALL ''' END + ' END' + CASE WHEN @source_as_temp_table = 0 THEN '+ ''(''+ ' ELSE ' + '' SELECT '' + ' END + @Actual_Values + CASE WHEN @source_as_temp_table = 0 THEN '+'')''' ELSE '' END + ' ' + 
+ COALESCE(@from,' FROM ' + @Source_Table_Qualified + ' (NOLOCK) ') + CASE WHEN @from IS NOT NULL AND CHARINDEX(@from, 'ORDER BY') > 0 THEN '' ELSE  ' ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) END
 
  DECLARE @output VARCHAR(MAX) = ''
  DECLARE @datasource VARCHAR(MAX) = ''

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -410,6 +410,8 @@ WHILE @Column_ID IS NOT NULL
  AND c.TABLE_SCHEMA = pk.TABLE_SCHEMA
  AND c.CONSTRAINT_NAME = pk.CONSTRAINT_NAME
  AND c.COLUMN_NAME = @Column_Name_Unquoted 
+ UNION
+ SELECT 1 WHERE @IDN = @Column_Name
  )
  BEGIN
  SET @Column_List_For_Update = @Column_List_For_Update + @Column_Name + ' = Source.' + @Column_Name + ', 

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -15,7 +15,7 @@ CREATE PROC sp_generate_merge
 (
  @table_name varchar(776), -- The table/view for which the MERGE statement will be generated using the existing data
  @target_table varchar(776) = NULL, -- Use this parameter to specify a different table name into which the data will be inserted/updated/deleted
- @from varchar(800) = NULL, -- Use this parameter to filter the rows based on a filter condition (using WHERE)
+ @from varchar(max) = NULL, -- Use this parameter to filter the rows based on a filter condition (using WHERE)
  @include_timestamp bit = 0, -- Specify 1 for this parameter, if you want to include the TIMESTAMP/ROWVERSION column's data in the MERGE statement
  @debug_mode bit = 0, -- If @debug_mode is set to 1, the SQL statements constructed by this procedure will be printed for later examination
  @schema varchar(64) = NULL, -- Use this parameter if you are not the owner of the table
@@ -492,7 +492,7 @@ BEGIN
 		SET @PK_column_list = @PK_column_list + '[' + @value + '], '
 		IF @different_join_nullable_columns IS NOT NULL AND CHARINDEX(@value, @different_join_nullable_columns) > 0
 		BEGIN
-			SET @PK_column_joins = '(' + @PK_column_joins + 'Target.[' + @value + '] = Source.[' + @value + '] OR Target.[' + @value + '] IS NULL AND Source.[' + @value + '] IS NULL) AND '
+			SET @PK_column_joins = @PK_column_joins + '(Target.[' + @value + '] = Source.[' + @value + '] OR Target.[' + @value + '] IS NULL AND Source.[' + @value + '] IS NULL) AND '
 		END
 		ELSE BEGIN
 			SET @PK_column_joins = @PK_column_joins + 'Target.[' + @value + '] = Source.[' + @value + '] AND '

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -616,7 +616,7 @@ BEGIN
 END
 
 IF LEN(@IDN) <> 0 AND @source_as_temp_table = 1 AND @output_identity_into_temp=1 BEGIN
-  SET @output += @b + 'CREATE TABLE #temp' + @table_name + '_Identity_Mapping(' + @IDN + ' INT, ' + REPLACE(@IDN, ']', '_Source]') + ' INT);'
+  SET @output += @b + 'CREATE TABLE #temp' + @table_name + '_Identity_Mapping(' + @IDN + ' INT, ' + REPLACE(@IDN, ']', '_Source]') + ' INT, Action Varchar(10));'
   SET @output += @b + 'ALTER TABLE #temp' + @table_name + ' ADD '+ REPLACE(@IDN, ']', '_Source]') + ' INT;'
 END;
 
@@ -675,7 +675,7 @@ IF @delete_if_not_matched=1 BEGIN
 END;
 
 IF LEN(@IDN) <> 0 AND @source_as_temp_table = 1 AND @output_identity_into_temp=1 BEGIN
- SET @output += @b + 'OUTPUT inserted.' + @IDN + ',Source.' + @IDN + ' AS ' + REPLACE(@IDN, ']', '_Source]') + ' INTO #temp' + @table_name + '_Identity_Mapping;'
+ SET @output += @b + 'OUTPUT inserted.' + @IDN + ',Source.' + @IDN + ' AS ' + REPLACE(@IDN, ']', '_Source], $action AS Action') + ' INTO #temp' + @table_name + '_Identity_Mapping;'
 END;
 
 SET @output += @b + ';'
@@ -708,6 +708,11 @@ BEGIN
 END
 
 IF LEN(@IDN) <> 0 AND @source_as_temp_table = 1 AND @output_identity_into_temp=1 BEGIN
+SET @output += @b + 'DECLARE @lInsertedCount INT, @lUpdatedCount INT, @lDeletedCount INT'
+	SET @output += @b + 'SELECT @lInsertedCount = SUM(CASE WHEN A.Action = ''INSERT'' THEN 1 ELSE 0 END), @lUpdatedCount = SUM(CASE WHEN A.Action = ''UPDATE'' THEN 1 ELSE 0 END), @lDeletedCount = SUM(CASE WHEN A.Action = ''DELETE'' THEN 1 ELSE 0 END)  FROM #temp' + @table_name + '_Identity_Mapping AS A;'
+	SET @output += @b + ' PRINT ''' + @Target_Table_For_Output + ' inserted by MERGE: '' + CAST(@lInsertedCount AS VARCHAR(100)) + '',  updated by MERGE:'' + CAST(@lUpdatedCount AS VARCHAR(100)) + '',  deleted by MERGE:'' + CAST(@lDeletedCount AS VARCHAR(100));';
+	SET @output += @b + @batch_separator
+	SET @output += @b + @b
  SET @output += @b + 'UPDATE T SET T.' + REPLACE(@IDN, ']', '_Source]') + ' = T1.' + REPLACE(@IDN, ']', '_Source], T.') + @IDN + ' = T1.' + @IDN + ' FROM #temp' + @table_name + ' AS T JOIN #temp' + @table_name + '_Identity_Mapping AS T1 ON T.' + @IDN + ' = T1.' + REPLACE(@IDN, ']', '_Source];')
  SET @output += @b + 'DROP TABLE #temp' + @table_name + '_Identity_Mapping;'
 END;

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -643,10 +643,10 @@ IF @source_as_temp_table = 1
 BEGIN
 	IF @ignore_duplicates_for_update = 0
 	BEGIN
-		SET @output += @b + 'USING (SELECT ' + @Column_List + ' FROM #temp' + @table_name
+		SET @output += @b + 'USING (SELECT TOP 9223372036854775807 ' + @Column_List + ' FROM #temp' + @table_name + ' ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list)
 	END
 	ELSE BEGIN
-		SET @output += @b + 'USING (SELECT ROW_NUMBER() OVER(PARTITION BY ' + REPLACE(@Column_List, @IDN +',', '') + ' ORDER BY ' + @IDN + ' DESC) AS RowNum,' + @Column_List + ' FROM #temp' + @table_name
+		SET @output += @b + 'USING (SELECT TOP 9223372036854775807 ROW_NUMBER() OVER(PARTITION BY ' + REPLACE(@Column_List, @IDN +',', '') + ' ORDER BY ' + @IDN + ' DESC) AS RowNum,' + @Column_List + ' FROM #temp' + @table_name + ' ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list)
 	END
 END
 ELSE BEGIN

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -1,6 +1,10 @@
 SET NOCOUNT ON
 GO
 
+--PRINT 'Using Master database'
+--USE master
+--GO
+
 PRINT 'Checking for the existence of this procedure'
 IF (SELECT OBJECT_ID('sp_generate_merge','P')) IS NOT NULL --means, the procedure already exists
  BEGIN

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -675,8 +675,8 @@ END
 
 --When NOT matched by target, perform an INSERT------------------------------------
 SET @output += @b + 'WHEN NOT MATCHED BY TARGET THEN';
-SET @output += @b + ' INSERT(' + CASE WHEN @output_identity_into_temp = 1 THEN REPLACE(@Column_List, @IDN +',', '') ELSE @Column_List END + ')'
-SET @output += @b + ' VALUES(' + REPLACE(CASE WHEN @output_identity_into_temp = 1 THEN REPLACE(@Column_List, @IDN +',', '') ELSE @Column_List END, '[', 'Source.[') + ')'
+SET @output += @b + ' INSERT(' + CASE WHEN @output_identity_into_temp = 1 AND LEN(@IDN) > 0 THEN REPLACE(@Column_List, @IDN +',', '') ELSE @Column_List END + ')'
+SET @output += @b + ' VALUES(' + REPLACE(CASE WHEN @output_identity_into_temp = 1 AND LEN(@IDN) > 0 THEN REPLACE(@Column_List, @IDN +',', '') ELSE @Column_List END, '[', 'Source.[') + ')'
 
 
 --When NOT matched by source, DELETE the row

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -605,7 +605,7 @@ BEGIN
 END
 
 --Determining whether to print IDENTITY_INSERT or not
-IF (LEN(@IDN) <> 0 AND @ommit_identity = 0)
+IF (LEN(@IDN) <> 0 AND @ommit_identity = 0 AND CHARINDEX('#', @Target_Table_For_Output) = 0 )
  BEGIN
  SET @output += @b + 'SET IDENTITY_INSERT ' + @Target_Table_For_Output + ' ON'
  SET @output += @b + ''
@@ -696,7 +696,7 @@ IF @disable_constraints = 1 AND (OBJECT_ID(@Source_Table_Qualified, 'U') IS NOT 
 
 
 --Switch-off identity inserting------------------------------------------------------
-IF (LEN(@IDN) <> 0) AND @ommit_identity = 0
+IF (LEN(@IDN) <> 0) AND @ommit_identity = 0 AND CHARINDEX('#', @Target_Table_For_Output) = 0 
  BEGIN
  SET @output +=      'SET IDENTITY_INSERT ' + @Target_Table_For_Output + ' OFF'
  SET @output += @b + @batch_separator

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -525,7 +525,7 @@ SET @Actual_Values =
  CASE WHEN @top IS NULL OR @top < 0 THEN '' ELSE ' TOP ' + LTRIM(STR(@top)) + ' ' END + 
  '''' + 
  ' '' + CASE WHEN ROW_NUMBER() OVER (ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) + ') = 1 THEN '' '' WHEN ROW_NUMBER() OVER (ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) + ') % 2000 = 0 AND 2 = ' + CONVERT(VARCHAR, CONVERT(INT,@split_query_for_source_temp_insert) + CONVERT(INT,@source_as_temp_table)) +' THEN ''' + CASE WHEN @source_as_temp_table = 1 AND @split_query_for_source_temp_insert = 1  THEN @insertTempSQL ELSE '''''' END + ''' ELSE ' + CASE WHEN @source_as_temp_table = 0 THEN ''',''' ELSE ''' UNION ALL ''' END + ' END' + CASE WHEN @source_as_temp_table = 0 THEN '+ ''(''+ ' ELSE ' + '' SELECT '' + ' END + @Actual_Values + CASE WHEN @source_as_temp_table = 0 THEN '+'')''' ELSE '' END + ' ' + 
- COALESCE(@from,' FROM ' + @Source_Table_Qualified + ' (NOLOCK) ') + CASE WHEN @from IS NOT NULL AND CHARINDEX(@from, 'ORDER BY') > 0 THEN '' ELSE  ' ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) END
+ COALESCE(@from,' FROM ' + @Source_Table_Qualified + ' (NOLOCK) ') + CASE WHEN @from IS NOT NULL AND CHARINDEX(SUBSTRING(@from, LEN(@from) - 500, 500), 'ORDER BY') > 0 THEN '' ELSE  ' ORDER BY ' + ISNULL(@columns_order_by, @PK_column_list) END
 
 
 


### PR DESCRIPTION
we have a table with about 5k records need to generate a merge script,
while I choose to not delete when not matched SQL Server would complaint
that 'query processor ran out of internal resources'.

I suppose as the merge source is all in memory and causing the trouble,
I moved all source into a temporary table and then use that as the
source for the merge and the script ran successful without any problem.

This doesn't mean it will run faster, in fact it might even slow it down
on limited disk resource servers, but at least it would run as SQL
Server won't consume too much memory to form the source table which
might causing the error.

ACTUAL ERROR is:

Msg 8623, Level 16, State 1, Line 8
The query processor ran out of internal resources and could not produce
a query plan. This is a rare event and only expected for extremely
complex queries or queries that reference a very large number of tables
or partitions. Please simplify the query. If you believe you have
received this message in error, contact Customer Support Services for
more information.
