### PR TITLE
Added N to strings output for unicode handling on some collations

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -15,7 +15,7 @@ GO
 
 --Turn system object marking on
 
-CREATE PROC sp_generate_merge
+CREATE PROC [sp_generate_merge]
 (
  @table_name varchar(776), -- The table/view for which the MERGE statement will be generated using the existing data
  @target_table varchar(776) = NULL, -- Use this parameter to specify a different table name into which the data will be inserted/updated/deleted
@@ -345,19 +345,19 @@ WHILE @Column_ID IS NOT NULL
  CASE 
  WHEN @Data_Type IN ('char','nchar') 
  THEN 
- 'COALESCE('''''''' + REPLACE(RTRIM(' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')'
+ 'COALESCE(''N'''''' + REPLACE(RTRIM(' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')'
  WHEN @Data_Type IN ('varchar','nvarchar') 
  THEN 
- 'COALESCE('''''''' + REPLACE(' + @Column_Name + ','''''''','''''''''''')+'''''''',''NULL'')'
+ 'COALESCE(''N'''''' + REPLACE(' + @Column_Name + ','''''''','''''''''''')+'''''''',''NULL'')'
  WHEN @Data_Type IN ('datetime','smalldatetime','datetime2','date') 
  THEN 
  'COALESCE('''''''' + RTRIM(CONVERT(char,' + @Column_Name + ',127))+'''''''',''NULL'')'
  WHEN @Data_Type IN ('uniqueidentifier') 
  THEN 
- 'COALESCE('''''''' + REPLACE(CONVERT(char(36),RTRIM(' + @Column_Name + ')),'''''''','''''''''''')+'''''''',''NULL'')'
+ 'COALESCE(''N'''''' + REPLACE(CONVERT(char(36),RTRIM(' + @Column_Name + ')),'''''''','''''''''''')+'''''''',''NULL'')'
  WHEN @Data_Type IN ('text') 
  THEN 
- 'COALESCE('''''''' + REPLACE(CONVERT(varchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
+ 'COALESCE(''N'''''' + REPLACE(CONVERT(varchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
  WHEN @Data_Type IN ('ntext') 
  THEN 
  'COALESCE('''''''' + REPLACE(CONVERT(nvarchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
@@ -666,4 +666,4 @@ GRANT EXEC ON sp_generate_merge TO public
 SET NOCOUNT OFF
 GO
 
-PRINT 'Done'
+END

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -666,4 +666,4 @@ GRANT EXEC ON sp_generate_merge TO public
 SET NOCOUNT OFF
 GO
 
-END
+PRINT 'Done'

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -366,7 +366,7 @@ WHILE @Column_ID IS NOT NULL
  'COALESCE('''''''' + REPLACE(CONVERT(nvarchar(max),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')' 
  WHEN @Data_Type IN ('binary','varbinary') 
  THEN 
- 'COALESCE(RTRIM(CONVERT(char,' + 'CONVERT(int,' + @Column_Name + '))),''NULL'')' 
+ 'COALESCE(RTRIM(CONVERT(varchar(max),' + @Column_Name + ', 1))),''NULL'')' 
  WHEN @Data_Type IN ('timestamp','rowversion') 
  THEN 
  CASE 


### PR DESCRIPTION
Hi, this sproc has been really useful for us in building seeddata for our tests. One thing I needed todo to get it working for us was to add `N` infront of the strings to fix the unicode inserts of text to NVARCHAR cols. This PR adds that in to the sproc.

Thanks for sharing it on github.