### PR TITLE
Change FROM parameter to nvarchar(max) to prevent syntax errors

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -19,7 +19,7 @@ CREATE PROC [sp_generate_merge]
 (
  @table_name varchar(776), -- The table/view for which the MERGE statement will be generated using the existing data
  @target_table varchar(776) = NULL, -- Use this parameter to specify a different table name into which the data will be inserted/updated/deleted
- @from varchar(800) = NULL, -- Use this parameter to filter the rows based on a filter condition (using WHERE)
+ @from nvarchar(max) = NULL, -- Use this parameter to filter the rows based on a filter condition (using WHERE)
  @include_timestamp bit = 0, -- Specify 1 for this parameter, if you want to include the TIMESTAMP/ROWVERSION column's data in the MERGE statement
  @debug_mode bit = 0, -- If @debug_mode is set to 1, the SQL statements constructed by this procedure will be printed for later examination
  @schema varchar(64) = NULL, -- Use this parameter if you are not the owner of the table


### PR DESCRIPTION
Change FROM parameter to nvarchar(max) to prevent syntax errors when WHERE clause was >800 characters