### PR TITLE
Fixed the error due to chop-off of trailing quotes

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -427,7 +427,7 @@ WHILE @Column_ID IS NOT NULL
 --To get rid of the extra characters that got concatenated during the last run through the loop
 IF LEN(@Column_List_For_Update) <> 0
  BEGIN
- SET @Column_List_For_Update = ' ' + LEFT(@Column_List_For_Update,len(@Column_List_For_Update) - 4)
+ SET @Column_List_For_Update = ' ' + LEFT(@Column_List_For_Update,len(@Column_List_For_Update) - 3)
  END
 
 IF LEN(@Column_List_For_Check) <> 0


### PR DESCRIPTION
Fixed the error due to chop-off of trailing quote **]** (closing square bracket char) in the column name in the "list for update" variable.