### PR TITLE
New change detection method: SHA2_256 hashvalue compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This procedure has explicit support for the following datatypes: (small)datetime
 
 The Image datatype is not supported and an error will be thrown if these are not excluded using the `@cols_to_exclude` parameter.
 
+When using the `@hash_compare_column` parameter, all columns in the source and target table must be implicitly convertible to strings (due to the use of `CONCAT` in the proc to calculate the hash value). This means that the following data types are not supported with `@hash_compare_column`: xml, hierarchyid, geometry and geography.
+
 
 ## Usage
 1. Ensure that your SQL client is configured to send results to grid.


### PR DESCRIPTION
This contribution comes from @lorberc

When the `@hashvalue_column='ColumnName'` param (added in this PR) is combined with `@update_only_if_changed=1` and `@include_values=0`, this allows for faster and more precise detection of changes to the source data over the usual method (which uses a `NULLIF`-based equality comparison). When the column is specified, change detection will be based on a `SHA2_256` hash of the source data, and that hash value will be inserted/updated in this `@target_table` column for later comparison.

This functionality may be of particular use when authoring ETL operations: significant performance gains may be felt, compared to the usual `NULLIF`-based change detection method, when executing the MERGE statement against larger datasets (>10,000 rows). This is due to the fact that the hash is persisted in the target table, so the data only needs to be compared once per execution.

#### Usage

To get started, you will need to add a column to the _target_ table that will store the hash value, e.g.:
```
ALTER TABLE [Person].[StateProvince] ADD [Hashvalue] varbinary (8000) NULL
```
(Note that it is not necessary to add a hash value column to the _source_ table, as this is calculated by the generated `MERGE` at execution time)

Then, to generate a MERGE statement that will update the target table if the calculated hash value of the source does not match the `[Hashvalue]` column in the target:
```
EXEC [DB].dbo.[sp_generate_merge] 
@schema = 'Person', 
@target_table = '[DB].[Person].[StateProvince]', 
@table_name = 'v_StateProvince',
@include_values = 0,   
@hash_compare_column = 'Hashvalue',
@include_rowsaffected = 0,
@nologo = 1,
@cols_to_join_on = "'ID'"
```
#### Limitations

To use this new change detection method, all columns in the source and target table must be implicitly convertible to strings (due to the use of `CONCAT` in the proc to calculate the hash value). This means that the following data types are not supported with `@hash_compare_column`: xml, hierarchyid, geometry and geography.

Furthermore, this functionality is currently not supported when combined with `@include_values = 1` (default).

#### Other changes

Other changes in this PR include:

* Superfluous batch separators (`GO` statements) removed
* Whitespace surrounding `MERGE` statement reformatted
* `[Target]` table alias is now specified in `WHEN MATCH UPDATE` clause, to avoid ambiguity
