### PR TITLE
Perform WITH CHECK upon re-enabling foreign key/check constraints

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -33,7 +33,7 @@ CREATE PROC [sp_generate_merge]
  @update_only_if_changed bit = 1, -- When 1, only performs an UPDATE operation if an included column in a matched row has changed.
  @hash_compare_column nvarchar(128) = NULL, -- When specified, change detection will be based on a SHA2_256 hash of the source data (the hash value will be stored in this @target_table column for later comparison; see Example 16)
  @delete_if_not_matched bit = 1, -- When 1, deletes unmatched source rows from target, when 0 source rows will only be used to update existing rows or insert new.
- @disable_constraints bit = 0, -- When 1, disables foreign key constraints and enables them after the MERGE statement
+ @disable_constraints bit = 0, -- When 1, disables foreign key/check constraints and enables them after the MERGE statement. This effectively postpones checking all constraints to after the MERGE has been performed.
  @ommit_computed_cols bit = 1, -- When 1, computed columns will not be included in the MERGE statement
  @ommit_generated_always_cols bit = 1, -- When 1, GENERATED ALWAYS columns will not be included in the MERGE statement
  @include_use_db bit = 1, -- When 1, includes a USE [DatabaseName] statement at the beginning of the generated batch
@@ -781,7 +781,7 @@ END
 --Re-enable the previously disabled constraints-------------------------------------
 IF @disable_constraints = 1 AND (OBJECT_ID(@Source_Table_Qualified, 'U') IS NOT NULL)
  BEGIN
- SET @output +=      'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ALL' --Code to enable the previously disabled constraints
+ SET @output +=      'ALTER TABLE ' + @Target_Table_For_Output + ' WITH CHECK CHECK CONSTRAINT ALL' --Code to enable the previously disabled constraints
  SET @output += @b + ISNULL(@batch_separator, '')
  SET @output += @b
  END


### PR DESCRIPTION
Fixes #39 by always checking data when `@disable_constraints=1` is used.

This not only ensures that all data in foreign key/check constraint columns is valid, but also ensures that [foreign keys can always be trusted by the SQL Server query optimizer](https://www.brentozar.com/blitz/foreign-key-trusted/).

This may result in reduced performance when the generated statements are executed, as all data will now be checked when constraint(s) are re-enabled. Additionally, if a table's constraints started in the `WITH NOCHECK` state prior to executing the MERGE, then it is possible that errors may start to be raised by SQL Server if the table contains invalid data (even if that invalid data is pre-existing). However the benefits of ensuring that the merged data is valid should outweigh these potential downsides.  

For users who wish to maintain the previous behaviour of disabling/enabling constraints before/after a merge without subsequently validating the data, use `@disable_constraints=0` with the proc and wrap the MERGE statement with the following `ALTER TABLE` statements:

```
ALTER TABLE [MyTableName] NOCHECK CONSTRAINT ALL
GO

-- (Generated merge statement)
MERGE [MyTableName]
...
GO

ALTER TABLE [MyTableName] CHECK CONSTRAINT ALL
GO
```