### PR TITLE
Preserve WITH CHECK status of foreign key and check constraints

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -679,9 +679,9 @@ IF (LEN(@IDN) <> 0)
 
 --Temporarily disable constraints on the target table
 IF @disable_constraints = 1 AND (OBJECT_ID(@Source_Table_Qualified, 'U') IS NOT NULL)
- BEGIN
- SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ALL' --Code to disable constraints temporarily
- END
+BEGIN
+	SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ALL' --Code to disable constraints temporarily
+END
 
 
 --Output the start of the MERGE statement, qualifying with the schema name only if the caller explicitly specified it
@@ -780,11 +780,11 @@ END
 
 --Re-enable the previously disabled constraints-------------------------------------
 IF @disable_constraints = 1 AND (OBJECT_ID(@Source_Table_Qualified, 'U') IS NOT NULL)
- BEGIN
- SET @output +=      'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ALL' --Code to enable the previously disabled constraints
- SET @output += @b + ISNULL(@batch_separator, '')
- SET @output += @b
- END
+BEGIN
+	SET @output += 'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ALL' --Code to enable the previously disabled constraints
+	SET @output += @b + ISNULL(@batch_separator, '')
+	SET @output += @b
+END
 
 
 --Switch-off identity inserting------------------------------------------------------

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -678,7 +678,7 @@ IF (LEN(@IDN) <> 0)
 
 
 --Temporarily disable constraints on the target table
-DECLARE @Source_Table_Constraints TABLE ([name] SYSNAME PRIMARY KEY, [is_not_trusted] bit, [is_disabled] bit)
+DECLARE @output_enable_constraints NVARCHAR(MAX) = ''
 DECLARE @ignore_disable_constraints BIT = IIF((OBJECT_ID(@Source_Table_Qualified, 'U') IS NULL), 1, 0)
 IF @disable_constraints = 1 AND @ignore_disable_constraints = 1
 BEGIN
@@ -686,12 +686,14 @@ BEGIN
 END
 ELSE IF @disable_constraints = 1
 BEGIN
+	DECLARE @Source_Table_Constraints TABLE ([name] SYSNAME PRIMARY KEY, [is_not_trusted] bit, [is_disabled] bit)
 	INSERT INTO @Source_Table_Constraints ([name], [is_not_trusted], [is_disabled])
 	SELECT [name], [is_not_trusted], [is_disabled] FROM sys.check_constraints WHERE parent_object_id = OBJECT_ID(@Source_Table_Qualified, 'U')
 	UNION
 	SELECT [name], [is_not_trusted], [is_disabled] FROM sys.foreign_keys WHERE parent_object_id = OBJECT_ID(@Source_Table_Qualified, 'U')
 
-	IF (SELECT COUNT(1) FROM @Source_Table_Constraints) = 0
+	DECLARE @Constraint_Ct INT = (SELECT COUNT(1) FROM @Source_Table_Constraints)
+	IF @Constraint_Ct = 0
 	BEGIN
 		PRINT 'Warning: @disable_constraints=1 will be ignored as there are no foreign key or check constraints on the source table'
 		SET @ignore_disable_constraints = 1
@@ -703,7 +705,48 @@ BEGIN
 	END
 	ELSE
 	BEGIN
-		SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ALL' -- Disable constraints temporarily
+		DECLARE @All_Constraints_Enabled BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_disabled] = 0) = @Constraint_Ct, 1, 0)
+		DECLARE @All_Constraints_Trusted BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_not_trusted] = 0) = @Constraint_Ct, 1, 0)
+		DECLARE @All_Constraints_NotTrusted BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_not_trusted] = 1) = @Constraint_Ct, 1, 0)
+
+		IF @All_Constraints_Enabled = 1 AND @All_Constraints_Trusted = 1
+		BEGIN
+			SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ALL' -- Disable constraints temporarily
+			SET @output_enable_constraints += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' WITH CHECK CHECK CONSTRAINT ALL' -- Enable the previously disabled constraints and re-check all data
+		END
+		ELSE IF @All_Constraints_Enabled = 1 AND @All_Constraints_NotTrusted = 1
+		BEGIN
+			SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ALL' -- Disable constraints temporarily
+			SET @output_enable_constraints += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ALL' -- Enable the previously disabled constraints, but don't re-check data 
+		END
+		ELSE
+		BEGIN
+			-- Selectively enable/disable constraints, with/without WITH CHECK, on a case-by-case basis
+			WHILE ((SELECT COUNT(1) FROM @Source_Table_Constraints) != 0)
+			BEGIN
+				DECLARE @Constraint_Item_Name SYSNAME = (SELECT TOP 1 [name] FROM @Source_Table_Constraints)
+				DECLARE @Constraint_Item_IsDisabled BIT = (SELECT TOP 1 [is_disabled] FROM @Source_Table_Constraints)
+				DECLARE @Constraint_Item_IsNotTrusted BIT = (SELECT TOP 1 [is_not_trusted] FROM @Source_Table_Constraints)
+
+				IF (@Constraint_Item_IsDisabled = 1)
+				BEGIN
+					DELETE FROM @Source_Table_Constraints WHERE [name] = @Constraint_Item_Name -- Don't enable this previously-disabled constraint
+					CONTINUE;
+				END
+
+				SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' NOCHECK CONSTRAINT ' + QUOTENAME(@Constraint_Item_Name)
+				IF (@Constraint_Item_IsNotTrusted = 1)
+				BEGIN
+					SET @output_enable_constraints += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ' + QUOTENAME(@Constraint_Item_Name) -- Enable the previously disabled constraint, but don't re-check data 
+				END
+				ELSE
+				BEGIN
+					SET @output_enable_constraints += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' WITH CHECK CHECK CONSTRAINT ' + QUOTENAME(@Constraint_Item_Name) -- Enable the previously disabled constraint and re-check all data
+				END
+
+				DELETE FROM @Source_Table_Constraints WHERE [name] = @Constraint_Item_Name
+			END
+		END
 	END
 END
 
@@ -805,46 +848,7 @@ END
 --Re-enable the temporarily disabled constraints-------------------------------------
 IF @disable_constraints = 1 AND @ignore_disable_constraints = 0
 BEGIN
-	DECLARE @Constraint_Ct INT = (SELECT COUNT(1) FROM @Source_Table_Constraints)
-	DECLARE @All_Constraints_Enabled BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_disabled] = 0) = @Constraint_Ct, 1, 0)
-	DECLARE @All_Constraints_Trusted BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_not_trusted] = 0) = @Constraint_Ct, 1, 0)
-	DECLARE @All_Constraints_NotTrusted BIT = IIF((SELECT COUNT(1) FROM @Source_Table_Constraints WHERE [is_not_trusted] = 1) = @Constraint_Ct, 1, 0)
-
-	IF @All_Constraints_Enabled = 1 AND @All_Constraints_Trusted = 1
-	BEGIN
-		SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' WITH CHECK CHECK CONSTRAINT ALL' -- Enable the previously disabled constraints and re-check all data
-	END
-	ELSE IF @All_Constraints_Enabled = 1 AND @All_Constraints_NotTrusted = 1
-	BEGIN
-		SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ALL' -- Enable the previously disabled constraints, but don't re-check data 
-	END
-	ELSE
-	BEGIN
-		-- Selectively enable/disable constraints, with/without WITH CHECK, on a case-by-case basis
-		WHILE ((SELECT COUNT(1) FROM @Source_Table_Constraints) != 0)
-		BEGIN
-			DECLARE @Constraint_Item_Name SYSNAME = (SELECT TOP 1 [name] FROM @Source_Table_Constraints)
-			DECLARE @Constraint_Item_IsDisabled BIT = (SELECT TOP 1 [is_disabled] FROM @Source_Table_Constraints)
-			DECLARE @Constraint_Item_IsNotTrusted BIT = (SELECT TOP 1 [is_not_trusted] FROM @Source_Table_Constraints)
-
-			IF (@Constraint_Item_IsDisabled = 1)
-			BEGIN
-				DELETE FROM @Source_Table_Constraints WHERE [name] = @Constraint_Item_Name -- Don't enable this previously-disabled constraint
-				CONTINUE;
-			END
-
-			IF (@Constraint_Item_IsNotTrusted = 1)
-			BEGIN
-				SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' CHECK CONSTRAINT ' + QUOTENAME(@Constraint_Item_Name) -- Enable the previously disabled constraint, but don't re-check data 
-			END
-			ELSE
-			BEGIN
-				SET @output += @b + 'ALTER TABLE ' + @Target_Table_For_Output + ' WITH CHECK CHECK CONSTRAINT ' + QUOTENAME(@Constraint_Item_Name) -- Enable the previously disabled constraint and re-check all data
-			END
-
-			DELETE FROM @Source_Table_Constraints WHERE [name] = @Constraint_Item_Name
-		END
-	END
+	SET @output += @output_enable_constraints
 	SET @output += @b + ISNULL(@batch_separator, '')
 	SET @output += @b
 END


### PR DESCRIPTION
(Replaces #62)

Fixes #39 when `@disable_constraints=1` is used by ensuring that, if the `WITH CHECK` state is present on a table constraint before the MERGE is performed, that it is preserved after the constraint is re-enabled (i.e. the data will be re-checked by SQL Server for validity).

Conversely, if `WITH NOCHECK` is set on the constraint, then that will also be preserved after the constraint is re-enabled (per current behaviour).

#### Behaviour change

Please note that this results in a slight behaviour change: as the new logic to generate the "disable/re-enable constraint" statements is based on the state of the constraints in the source table (as specified in `@table_name`), the `@disable_constraints=1` flag will be ignored when generating the output T-SQL in the following circumstances:

* If the source table has no foreign key or check constraints on it
* If all of the FK/check constraints on the source table are disabled

Furthermore, if the table contains a mix of enabled and disabled constraints, then the disabled constraints will be excluded from the generated output.

In the above cases, a warning will instead be printed as the output is being generated (see the Messages tab in SSMS).

For users who wish to maintain the previous behaviour of disabling/enabling all table constraints regardless of their state in the source table, use `@disable_constraints=0` with the proc and wrap the MERGE statement with the following `ALTER TABLE` statements:

```
ALTER TABLE [MyTableName] NOCHECK CONSTRAINT ALL
GO

-- (Generated merge statement)
MERGE [MyTableName]
...
GO

ALTER TABLE [MyTableName] CHECK CONSTRAINT ALL
GO
```
Note that you may want to amend the latter statement to `ALTER TABLE [MyTableName] WITH CHECK CHECK CONSTRAINT ALL` if you'd like SQL to check table data upon re-enabling the constraint (otherwise the constraints will be flagged by SQL as "not trusted").