### PR TITLE
Ensure scope safety when a temp table is specified

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -266,7 +266,7 @@ BEGIN
 		PRINT 'To resolve, execute the proc in the context of [tempdb], e.g. EXEC tempdb.dbo.sp_generate_merge @table_name=''' + @table_name + ''''
 		RETURN -1 --Failure. Reason: Temporary tables cannot be referenced in a user db
 	END
-	SET @Internal_Table_Name = (SELECT [name] FROM sys.objects WHERE [name] LIKE @table_name + '[_]%')
+	SET @Internal_Table_Name = (SELECT [name] FROM sys.objects WHERE [object_id] = OBJECT_ID(@table_name))
 END
 ELSE
 BEGIN


### PR DESCRIPTION
Previous logic just picked any temp table it found matching the specified name (supplied via the `@table_name='#tempTableName'` parameter), regardless of which session it belonged to. This may have resulted in the wrong table metadata being used to construct the merge statement.