### PR TITLE
Show inserted/updated/deleted row counts instead of just total rows affected

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -842,7 +842,8 @@ IF @include_rowsaffected = 1
 BEGIN
  SET @output += @b + 'DECLARE @mergeError int'
  SET @output += @b + ' , @mergeCount int, @mergeCountIns int, @mergeCountUpd int, @mergeCountDel int'
- SET @output += @b + 'SELECT @mergeError = @@ERROR, @mergeCount = ( SELECT COUNT(1) FROM @mergeOutput ), @mergeCountIns = ( SELECT COUNT(1) FROM @mergeOutput WHERE [DMLAction] = ''INSERT'' ), @mergeCountUpd = ( SELECT COUNT(1) FROM @mergeOutput WHERE [DMLAction] = ''UPDATE'' ), @mergeCountDel = ( SELECT COUNT(1) FROM @mergeOutput WHERE [DMLAction] = ''DELETE'' ) '
+ SET @output += @b + 'SELECT @mergeError = @@ERROR'
+ SET @output += @b + 'SELECT @mergeCount = COUNT(1), @mergeCountIns = SUM(IIF([DMLAction] = ''INSERT'', 1, 0)), @mergeCountUpd = SUM(IIF([DMLAction] = ''UPDATE'', 1, 0)), @mergeCountDel = SUM (IIF([DMLAction] = ''DELETE'', 1, 0)) FROM @mergeOutput'
  SET @output += @b + 'IF @mergeError != 0'
  SET @output += @b + ' BEGIN'
  SET @output += @b + ' PRINT ''ERROR OCCURRED IN MERGE FOR ' + @Target_Table_For_Output + '. Rows affected: '' + CAST(@mergeCount AS VARCHAR(100)); -- SQL should always return zero rows affected';

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -850,7 +850,7 @@ BEGIN
  SET @output += @b + ' END'
  SET @output += @b + 'ELSE'
  SET @output += @b + ' BEGIN'
- SET @output += @b + ' PRINT ''' + @Target_Table_For_Output + ' rows affected by MERGE: '' + CAST(@mergeCount AS VARCHAR(100)) + '' (Inserted: '' + CAST(@mergeCountIns AS VARCHAR(100)) + ''; Updated: '' + CAST(@mergeCountUpd AS VARCHAR(100)) + ''; Deleted: '' + CAST(@mergeCountDel AS VARCHAR(100)) + '')'' ;'
+ SET @output += @b + ' PRINT ''' + @Target_Table_For_Output + ' rows affected by MERGE: '' + CAST(COALESCE(@mergeCount,0) AS VARCHAR(100)) + '' (Inserted: '' + CAST(COALESCE(@mergeCountIns,0) AS VARCHAR(100)) + ''; Updated: '' + CAST(COALESCE(@mergeCountUpd,0) AS VARCHAR(100)) + ''; Deleted: '' + CAST(COALESCE(@mergeCountDel,0) AS VARCHAR(100)) + '')'' ;'
  SET @output += @b + ' END'
  SET @output += @b + ISNULL(@batch_separator, '')
  SET @output += @b + @b


### PR DESCRIPTION
SQL MERGE does not output @@ROWCOUNT properly (for a MERGE statement, @@ROWCOUNT = last operation's row count instead of the entire operation's row count). Updating the logic to capture it correctly.