### PR TITLE
added optional parameters @update_existing and @max_rows_per_batch

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -265,6 +265,13 @@ IF (PARSENAME(@table_name,3)) IS NOT NULL
 	RETURN -1 --Failure. Reason: Invalid use of @max_rows_per_batch and @delete_if_not_matched properties
  END
 
+ IF @max_rows_per_batch <= 0
+ BEGIN
+	RAISERROR('Invalid use of @max_rows_per_batch',16,1)
+	PRINT 'The @max_rows_per_batch param must be set to 1 or higher.'
+	RETURN -1 --Failure. Reason: Invalid use of @max_rows_per_batch
+ END
+ 
 DECLARE @Internal_Table_Name NVARCHAR(128)
 IF PARSENAME(@table_name,1) LIKE '#%'
 BEGIN

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -644,7 +644,7 @@ SET @Actual_Values =
  'SELECT ' + 
  CASE WHEN @top IS NULL OR @top < 0 THEN '' ELSE ' TOP ' + LTRIM(STR(@top)) + ' ' END + 
  '''' + 
- ' '' + CASE WHEN ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) = 1 THEN '' '' ELSE '','' END + ''(''+ ' + @Actual_Values + '+'')''' + ' ' + 
+ ' '' + ''(''+ ' + @Actual_Values + '+'')''' + ' ' + 
  COALESCE(@from,' FROM ' + @Source_Table_Qualified + ' (NOLOCK) ORDER BY ' + @PK_column_list)
 
  SET @output = CASE WHEN ISNULL(@results_to_text, 1) = 1 THEN '' ELSE '---' END
@@ -870,7 +870,7 @@ SET @outputMergeBatch += ';' + @b
 		SET @ValuesListIDTo = @ValuesListIDFrom + @max_rows_per_batch - 1
 		SET @CurrentValuesList = ''
 
-		SET @CurrentValuesList += CAST((SELECT @b + val
+		SET @CurrentValuesList += CAST((SELECT @b + CASE WHEN ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) = 1 THEN ' ' ELSE ',' END + val
 						FROM @tab
 						WHERE ID BETWEEN @ValuesListIDFrom AND @ValuesListIDTo
 						ORDER BY ID FOR XML PATH('')) AS XML).value('.', 'NVARCHAR(MAX)');

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -196,6 +196,9 @@ SELECT * INTO #CurrencyRateFiltered FROM AdventureWorks2017.Sales.CurrencyRate W
 ALTER TABLE #CurrencyRateFiltered ADD CONSTRAINT PK_Sales_CurrencyRate PRIMARY KEY CLUSTERED ( CurrencyRateID )
 EXEC tempdb.dbo.sp_generate_merge @table_name='#CurrencyRateFiltered', @target_table='[AdventureWorks2017].[Sales].[CurrencyRate]', @delete_if_not_matched = 0, @include_use_db = 0;
 
+Example 19: To generate a MERGE split into batches based on a max rowcount per batch. NOTE: @delete_if_not_matched must be 0, and @include_values must be 1.
+
+EXEC [AdventureWorks2017].dbo.[sp_generate_merge] @table_name = 'MyTable', @schema = 'dbo', @delete_if_not_matched = 0, @max_rows_per_batch = 100
  
 ***********************************************************************************************************/
 
@@ -262,6 +265,13 @@ IF (PARSENAME(@table_name,3)) IS NOT NULL
  BEGIN
 	RAISERROR('Invalid use of @max_rows_per_batch property incombination with @delete_if_not_matched',16,1)
 	PRINT 'The @max_rows_per_batch param is set, however @delete_if_not_matched is set to 1. To utilize batch-based merge, please ensure @delete_if_not_matched is set to 0.'
+	RETURN -1 --Failure. Reason: Invalid use of @max_rows_per_batch and @delete_if_not_matched properties
+ END
+
+ IF @max_rows_per_batch IS NOT NULL AND @include_values = 0
+ BEGIN
+	RAISERROR('Invalid use of @max_rows_per_batch property incombination with @include_values',16,1)
+	PRINT 'The @max_rows_per_batch param is set, however @include_values is set to 0. To utilize batch-based merge, please ensure @include_values is set to 1.'
 	RETURN -1 --Failure. Reason: Invalid use of @max_rows_per_batch and @delete_if_not_matched properties
  END
 

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -786,7 +786,7 @@ DECLARE @tab TABLE (ID INT NOT NULL PRIMARY KEY IDENTITY(1,1), val NVARCHAR(max)
 
 IF @include_values = 1
 BEGIN
- SET @@outputMergeBatch += @b + 'USING ('
+ SET @outputMergeBatch += @b + 'USING ('
  --All the hard work pays off here!!! You'll get your MERGE statement, when the next line executes!
  INSERT INTO @tab (val)
  EXEC (@Actual_Values)

--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -870,10 +870,10 @@ SET @outputMergeBatch += ';' + @b
 		SET @ValuesListIDTo = @ValuesListIDFrom + @max_rows_per_batch - 1
 		SET @CurrentValuesList = ''
 
-		SET @CurrentValuesList += CAST((SELECT @b + CASE WHEN ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) = 1 THEN ' ' ELSE ',' END + val
-									FROM @tab
-									WHERE ID BETWEEN @ValuesListIDFrom AND @ValuesListIDTo
-									ORDER BY ID FOR XML PATH('')) AS XML).value('.', 'NVARCHAR(MAX)');
+		SET @CurrentValuesList += CAST((SELECT @b + val
+						FROM @tab
+						WHERE ID BETWEEN @ValuesListIDFrom AND @ValuesListIDTo
+						ORDER BY ID FOR XML PATH('')) AS XML).value('.', 'NVARCHAR(MAX)');
 		
 		SET @output += REPLACE(@outputMergeBatch, '{{ValuesList}}', @CurrentValuesList) + @b;
 


### PR DESCRIPTION
The addition of the optional parameter `@max_rows_per_batch` fixes issues #19 and #11. It splits the MERGE command into multiple batches, each batch merges a maximum number of rows as specified.

Additionally, this PR adds the optional parameter `@update_existing` which toggles the use of the UPDATE clause in the MERGE command.
This is different from the `@update_only_if_changed` parameter which only toggles whether there would be a check for changed data before updating a row. But the UPDATE clause is still added.
The parameter `@update_existing`, when set to 0, will remove the UPDATE clause entirely.


```
 @update_existing bit = 1, -- When 1, performs an UPDATE operation on existing rows.
 @max_rows_per_batch int = NULL -- When not NULL, splits the MERGE command into multiple batches, each batch merges X rows as specified
```