### PR TITLE
Fix 'incorrect settings' error on DBs/clients with SET QUOTED_IDENTIFIER OFF

### DIFF
--- a/master.dbo.sp_generate_merge.sql
+++ b/master.dbo.sp_generate_merge.sql
@@ -1,4 +1,5 @@
 SET NOCOUNT ON
+SET QUOTED_IDENTIFIER ON
 GO
 
 PRINT 'Using Master database'
@@ -198,7 +199,7 @@ Example 19: To generate a MERGE split into batches based on a max rowcount per b
 ***********************************************************************************************************/
 
 SET NOCOUNT ON
-
+SET QUOTED_IDENTIFIER ON
 
 --Making sure user only uses either @cols_to_include or @cols_to_exclude
 IF ((@cols_to_include IS NOT NULL) AND (@cols_to_exclude IS NOT NULL))


### PR DESCRIPTION
Added "SET QUOTED_IDENTIFIER ON" on lines 2 and 202.  I was getting an error:

SELECT failed because the following SET options have incorrect settings: 'QUOTED_IDENTIFIER'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operations.

I found an apparent solution at https://dba.stackexchange.com/a/233473 and then further down someone points out that you need to add that to the procedure as well as within the query window.  It can be added before the procedure create, which is how I've done it here, and I also added it inside the procedure.  I think it may be only needed within the proc, but I don't believe it'll hurt..