### PR TITLE
Fix script compatibility with Binary (BIN) database collations

### DIFF
--- a/sp_generate_merge.sql
+++ b/sp_generate_merge.sql
@@ -354,7 +354,7 @@ DECLARE @Column_ID int,
 IF @hash_compare_column IS NOT NULL  --Check existence of column [Hashvalue] in target table and raise error in case of missing
 BEGIN
   IF @target_table IS NULL SET @target_table = @table_name COLLATE DATABASE_DEFAULT
-  SET @SQL =
+  SET @sql =
     'SELECT @columnname = column_name
     FROM ' + COALESCE(PARSENAME(@target_table COLLATE DATABASE_DEFAULT,3),QUOTENAME(DB_NAME())) + '.INFORMATION_SCHEMA.COLUMNS (NOLOCK)
     WHERE TABLE_NAME = ''' + PARSENAME(@target_table COLLATE DATABASE_DEFAULT,1) + '''' +


### PR DESCRIPTION
When Server Collation or the master Database Collation are *_**BIN**, for example Cyrillic_General_BIN scripts fails with error: 
`"Msg 137, Level 15, State 1 Must declare the scalar variable @SQL"`

![image](https://github.com/dnlnln/generate-sql-merge/assets/22933602/71ef9ee1-fd71-4e33-a866-d11748712d67)
