### PR TITLE
Add SERIALIZABLE table hint to prevent race condition in concurrent executions

### DIFF
--- a/sp_generate_merge.sql
+++ b/sp_generate_merge.sql
@@ -790,7 +790,7 @@ END
 DECLARE @outputMergeBatch nvarchar(max), @ValuesListTotalCount int;
 
 --Output the start of the MERGE statement, qualifying with the schema name only if the caller explicitly specified it
-SET @outputMergeBatch = @b COLLATE DATABASE_DEFAULT + 'MERGE INTO ' + @Target_Table_For_Output COLLATE DATABASE_DEFAULT + ' AS [Target]'
+SET @outputMergeBatch = @b COLLATE DATABASE_DEFAULT + 'MERGE INTO ' + @Target_Table_For_Output COLLATE DATABASE_DEFAULT + ' WITH (SERIALIZABLE) AS [Target]'
 DECLARE @tab TABLE (ID INT NOT NULL PRIMARY KEY IDENTITY(1,1), val NVARCHAR(max));
 
 IF @include_values = 1


### PR DESCRIPTION
Adds the `WITH (SERIALIZABLE)` hint to prevent inconsistent results when more than one simultaneous execution of a MERGE or INSERT/UPDATE occurs on a given table.

For more information, see:
* https://dba.stackexchange.com/a/317527/2767
* https://web.archive.org/web/20210405205926/https://weblogs.sqlteam.com/dang/2009/01/31/upsert-race-condition-with-merge/