### PR TITLE
Fix @hashcolumn param error w- different target schema

### DIFF
--- a/sp_generate_merge.sql
+++ b/sp_generate_merge.sql
@@ -438,7 +438,7 @@ BEGIN
     'SELECT @columnname = column_name
     FROM ' + COALESCE(PARSENAME(@target_table COLLATE DATABASE_DEFAULT,3),QUOTENAME(DB_NAME())) + '.INFORMATION_SCHEMA.COLUMNS (NOLOCK)
     WHERE TABLE_NAME = ''' + PARSENAME(@target_table COLLATE DATABASE_DEFAULT,1) + '''' +
-    ' AND TABLE_SCHEMA = ' + '''' + COALESCE(@schema COLLATE DATABASE_DEFAULT, SCHEMA_NAME()) + '''' + ' AND [COLUMN_NAME] = ''' + @hash_compare_column COLLATE DATABASE_DEFAULT + ''''
+    ' AND TABLE_SCHEMA = ' + '''' + COALESCE(PARSENAME(@target_table COLLATE DATABASE_DEFAULT,2), @schema COLLATE DATABASE_DEFAULT, SCHEMA_NAME()) + '''' + ' AND [COLUMN_NAME] = ''' + @hash_compare_column COLLATE DATABASE_DEFAULT + ''''
   EXECUTE sp_executesql @sql, N'@columnname nvarchar(128) OUTPUT', @columnname = @checkhashcolumn OUTPUT
   IF @checkhashcolumn IS NULL
   BEGIN


### PR DESCRIPTION
From @lorberc:

>I just came across a small bug concerning the check for `@checkhashcolumn`.
>Here we're looking for @hash_compare_column for TABLE_SCHEMA = `@schema` first. `@schema` refers to the source schema which, in this case, is the wrong schema cause the hashcolumn only can be found for the target schema.
>We need to check the target schema first, so by replacing to:  
`' AND TABLE_SCHEMA = ' + '''' + COALESCE(PARSENAME(@target_table COLLATE DATABASE_DEFAULT,2),SCHEMA_NAME()) + '''' + ' AND [COLUMN_NAME] = ''' + @hash_compare_column COLLATE DATABASE_DEFAULT + '''' `
we're safe.

Made a slight change to the above so that, if only the (unqualified) table name is supplied in `@target_table` that it defaults to the `@schema` param, if specified by the user. My thinking was that the param name `@schema` is assumed to refer to either the source or the target schema. If the user wants to specify otherwise, they can of course fully-qualify the `@target_table` param.