### PR TITLE
Fix for geometry/geography types

### DIFF
--- a/sp_generate_merge.sql
+++ b/sp_generate_merge.sql
@@ -510,11 +510,11 @@ WHILE @Column_ID IS NOT NULL
 BEGIN
   SELECT @Column_Name = QUOTENAME(c.name), 
          @Column_Name_Unquoted = c.name,
-         @Data_Type = bt.name
+         @Data_Type = COALESCE(bt.name, tp.name)
   FROM sys.columns c
   INNER JOIN sys.tables t ON c.object_id = t.object_id
   INNER JOIN sys.types tp ON c.user_type_id = tp.user_type_id
-  INNER JOIN sys.types bt ON tp.system_type_id = bt.user_type_id AND tp.system_type_id = bt.system_type_id
+  LEFT JOIN sys.types bt ON tp.system_type_id = bt.user_type_id AND tp.system_type_id = bt.system_type_id
   WHERE c.column_id = @Column_ID
     AND t.name = @Internal_Table_Name COLLATE DATABASE_DEFAULT
     AND t.schema_id = COALESCE(SCHEMA_ID(@schema COLLATE DATABASE_DEFAULT), SCHEMA_ID())


### PR DESCRIPTION
Some types have a different system_type_id and user_type_id, which means the inner join will not work. That goes for the following types:

|name|system_type_id|user_type_id|
|-|-|-|
|hierarchyid|240|128|
|geometry|240|129|
|geography|240|130|

Without this change, the query returns no rows, which results in duplicate source columns, which is an invalid result